### PR TITLE
fix: configure git HTTPS auth for org package deps in ci-theme

### DIFF
--- a/.github/workflows/ci-theme.yml
+++ b/.github/workflows/ci-theme.yml
@@ -27,6 +27,8 @@ on:
         required: false
       ITINERIS_NPM_AUTH_TOKEN:
         required: false
+      ITINERIS_REPO_READ_TOKEN:
+        required: false
 
 jobs:
   check-theme-changes:
@@ -55,6 +57,8 @@ jobs:
         working-directory: web/app/themes/${{ inputs.THEME_NAME }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node ${{ inputs.NODE_VERSION }}
         uses: actions/setup-node@v6.4.0
@@ -67,6 +71,14 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ITINERIS_NPM_AUTH_TOKEN: ${{ secrets.ITINERIS_NPM_AUTH_TOKEN }}
+
+      - name: Configure git auth for org packages
+        run: |
+          if [ -n "${ITINERIS_REPO_READ_TOKEN}" ]; then
+            git config --global url."https://x-access-token:${ITINERIS_REPO_READ_TOKEN}@github.com/ItinerisLtd/".insteadOf "https://github.com/ItinerisLtd/"
+          fi
+        env:
+          ITINERIS_REPO_READ_TOKEN: ${{ secrets.ITINERIS_REPO_READ_TOKEN }}
 
       - name: Install dependencies with Yarn
         working-directory: web/app/themes/${{ inputs.THEME_NAME }}

--- a/.github/workflows/trellis-deploy.yml
+++ b/.github/workflows/trellis-deploy.yml
@@ -52,6 +52,8 @@ on:
         required: false
       ITINERIS_NPM_AUTH_TOKEN:
         required: false
+      ITINERIS_REPO_READ_TOKEN:
+        required: false
       TAILSCALE_OAUTH_CLIENT_ID:
         required: true
       TAILSCALE_OAUTH_SECRET:
@@ -92,6 +94,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: bedrock
+          persist-credentials: false
+
+      - name: Configure git auth for org packages
+        run: |
+          if [ -n "${ITINERIS_REPO_READ_TOKEN}" ]; then
+            git config --global url."https://x-access-token:${ITINERIS_REPO_READ_TOKEN}@github.com/ItinerisLtd/".insteadOf "https://github.com/ItinerisLtd/"
+          fi
+        env:
+          ITINERIS_REPO_READ_TOKEN: ${{ secrets.ITINERIS_REPO_READ_TOKEN }}
 
       - name: Setup Node ${{ inputs.NODE_VERSION }}
         uses: actions/setup-node@v6.4.0


### PR DESCRIPTION
Add optional `ITINERIS_REPO_READ_TOKEN` secret support to `ci-theme` workflow for projects that install packages from private org repositories via git URLs.

- Set `persist-credentials: false` on node job checkout
- Add conditional git URL rewrite step using the token
- Projects not passing this secret are unaffected