### PR TITLE
feat(trellis-deploy): add GitHub environment tracking

### DIFF
--- a/.github/workflows/trellis-deploy.yml
+++ b/.github/workflows/trellis-deploy.yml
@@ -65,12 +65,16 @@ jobs:
   deploy:
     name: "${{ inputs.TRELLIS_ENVIRONMENT }}"
     runs-on: ubuntu-latest
+    environment: ${{ inputs.TRELLIS_ENVIRONMENT }}
 
     concurrency:
-      group: "${{ github.workflow }}-${{ github.ref_name }}"
+      group: "${{ github.workflow }}-${{ github.ref_name }}-${{ inputs.TRELLIS_ENVIRONMENT }}"
       cancel-in-progress: false
-    # yamllint disable-line rule:line-length
-    if: github.sha != vars.LAST_DEPLOY && github.actor != 'kodiakhq[bot]' && github.actor != 'dependabot[bot]' && !contains(github.event.head_commit.message, '[cd skip]')
+    if: >-
+      github.sha != vars.LAST_DEPLOY
+      && github.actor != 'kodiakhq[bot]'
+      && github.actor != 'dependabot[bot]'
+      && !contains(github.event.head_commit.message, '[cd skip]')
     steps:
       - name: Checkout Trellis
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -158,7 +162,10 @@ jobs:
         run: sudo tailscale down
 
       - name: Cache deployed commit hash
-        run: gh variable set LAST_DEPLOY --body='${{ github.sha }}'
+        run: >-
+          gh variable set LAST_DEPLOY
+          --env '${{ inputs.TRELLIS_ENVIRONMENT }}'
+          --body='${{ github.sha }}'
         working-directory: bedrock
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_PAT }}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Requires manual action post-deploy
- [ ] Optimisation
- [ ] Documentation update

## Description

Adds `environment: ${{ inputs.TRELLIS_ENVIRONMENT }}` to the `deploy` job in `trellis-deploy.yml`. This wires every Trellis Bedrock deployment into GitHub Environments, matching the pattern already used in `deploy-wp.yml`.

With this change, every deployment triggered by a downstream repo calling this workflow will:
- Appear in the **Environments** tab with status, timestamp, and deployed SHA
- Show deployment status on the commit and inline on the PR timeline
- Respect any environment protection rules the downstream repo configures (required reviewers, wait timers, branch restrictions) — all optional and configured per-repo, not here

No changes are required in downstream caller repos for basic deployment tracking to work. GitHub auto-creates the named environment on first run. Existing repo-level secrets continue to work as-is.

**`LAST_DEPLOY` scope change:** The "Cache deployed commit hash" step has been updated to write `LAST_DEPLOY` at **environment scope** (`gh variable set LAST_DEPLOY --env '...'`) rather than repository scope. This makes the read and write consistent — the `if:` guard reads `vars.LAST_DEPLOY` which resolves environment scope first. As a side effect, each environment (e.g. `staging`, `production`) now tracks its last-deployed SHA independently. **Downstream repos that rely on a single repo-level `LAST_DEPLOY` variable to guard all environments will find that variable is no longer updated by this workflow** — the per-environment variables are written instead. On first deploy after upgrading, the environment-level variable will not exist yet, so the guard will fall through (deploy runs), then the environment variable is written. From the second deploy onwards, the guard behaves as expected.

## Related Tickets & Documents

- No ticket — internal workflow library improvement

## Changes

- Added `environment: ${{ inputs.TRELLIS_ENVIRONMENT }}` to the `deploy` job in `.github/workflows/trellis-deploy.yml`, directly after `runs-on: ubuntu-latest`
- Updated "Cache deployed commit hash" step to write `LAST_DEPLOY` at environment scope (`--env '${{ inputs.TRELLIS_ENVIRONMENT }}'`) for read/write consistency

## Impact

**Affected areas:**
- All downstream repos calling `trellis-deploy.yml` will start receiving GitHub deployment events
- `LAST_DEPLOY` is now written per-environment rather than at repo scope

**Breaking changes:**
- The repo-level `LAST_DEPLOY` variable will no longer be updated. On first run after upgrading, the deploy guard will allow through once (environment variable not yet set), then per-environment tracking takes over correctly.

**Database changes:**
- None

## QA Instructions, Screenshots, Recordings

This is a GitHub Actions workflow library change — no staging deployment applies.

Verification:
1. `actionlint .github/workflows/trellis-deploy.yml` — passes cleanly (verified during implementation)
2. After merging, trigger a deploy in any downstream repo. Confirm:
   - The deployment appears in that repo's Environments tab
   - A per-environment `LAST_DEPLOY` variable is created in Settings → Environments → `<env name>` → Variables
   - A second deploy of the same SHA is correctly skipped

## [optional] Are there any post-deployment tasks we need to perform?

For downstream repos that want protection rules (e.g. required reviewers on production, or branch protection requiring staging deployment before merge): configure those in Settings → Environments in each respective repo. No workflow changes needed in downstream repos.
