### PR TITLE
Reset OPcache after deploy via itineris-opcache-purge

### DIFF
--- a/.github/workflows/trellis-deploy.yml
+++ b/.github/workflows/trellis-deploy.yml
@@ -60,6 +60,10 @@ on:
         required: true
       TAILSCALE_EXIT_NODE:
         required: true
+      OPCACHE_PURGE_TOKEN:
+        required: false
+      OPCACHE_PURGE_USER_AGENT:
+        required: false
 
 jobs:
   deploy:
@@ -157,6 +161,39 @@ jobs:
           # yamllint disable-line rule:line-length
           FONTAWESOME_NPM_AUTH_TOKEN: "${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}"
           ITINERIS_NPM_AUTH_TOKEN: ${{ secrets.ITINERIS_NPM_AUTH_TOKEN }}
+
+      - name: Reset OPcache
+        working-directory: trellis
+        env:
+          OPCACHE_PURGE_TOKEN: ${{ secrets.OPCACHE_PURGE_TOKEN }}
+          OPCACHE_PURGE_USER_AGENT: ${{ secrets.OPCACHE_PURGE_USER_AGENT }}
+          TRELLIS_ENVIRONMENT: ${{ inputs.TRELLIS_ENVIRONMENT }}
+        run: |
+          if [ -z "${OPCACHE_PURGE_TOKEN}" ]; then
+            echo 'OPCACHE_PURGE_TOKEN not configured - skipping OPcache reset.'
+            exit 0
+          fi
+          HOSTS="$(python3 -c '
+          import os, yaml
+          env = os.environ["TRELLIS_ENVIRONMENT"]
+          with open(f"group_vars/{env}/wordpress_sites.yml") as f:
+              sites = yaml.safe_load(f).get("wordpress_sites") or {}
+          for site in sites.values():
+              hosts = site.get("site_hosts") or []
+              if hosts and hosts[0].get("canonical"):
+                  print(hosts[0]["canonical"])
+          ')"
+          for HOST in ${HOSTS}; do
+            BODY="$(curl --silent --max-time 30 \
+              --user-agent "${OPCACHE_PURGE_USER_AGENT:-ItinerisServer/1.0}" \
+              --header "X-Opcache-Purge: ${OPCACHE_PURGE_TOKEN}" \
+              "https://${HOST}/?opcache_purge=deploy-${GITHUB_SHA}" || true)"
+            if printf '%s' "${BODY}" | grep -q '"reset":true'; then
+              echo "OPcache reset: OK (${HOST})"
+            else
+              echo "::warning::OPcache purge not confirmed for ${HOST} (mu-plugin missing, token mismatch, or edge block). Deploy unaffected."
+            fi
+          done
 
       - name: Disconnect from Tailscale
         run: sudo tailscale down


### PR DESCRIPTION
## What

After `trellis deploy`, call the [itineris-opcache-purge](https://github.com/ItinerisLtd/itineris-opcache-purge) endpoint on every site host found in the trellis checkout's `group_vars/<env>/wordpress_sites.yml`. This replaces the per-project trellis deploy hook / Galaxy role approach: **trellis repos need no changes, ever** — the purge lives entirely in this org workflow.

## Why

Atomic Trellis deploys stack `releases/<id>` paths in OPcache until it saturates and PHP recompiles every script on every request (measured: frpadvisory TTFB 2.4→1.0s, stelizabethhospice 4.5→1.1s). Currently fixed on 5 sites via a Galaxy role reading a per-project vault token; per Tim's simplification decision the mechanism moves here, with one org-level token and zero per-project trellis/vault plumbing.

## Design notes

- **Inert without the secret** — callers that don't pass `OPCACHE_PURGE_TOKEN` get one log line and a clean skip, so this is safe to merge and tag before any caller changes.
- **Fail-safe** — the step can never fail a deploy; an unconfirmed purge emits a `::warning::` annotation (mu-plugin not installed yet, token mismatch, edge block).
- **Placement** — after `Deploy`, before `tailscale down`, so the purge egresses identically to the deploy itself.
- **Multi-site aware** — loops every site in the trellis config (e.g. questionmark's www + workmates).
- **No token leakage** — token travels only in a header (never the URL), GH masks secret values in logs.
- **`OPCACHE_PURGE_USER_AGENT`** (optional org secret) — sent so Kinsta Bot Protection whitelists can match a non-public UA; falls back to `ItinerisServer/1.0` (today's public string) when unset.

Both secrets exist at org level already. Verified locally: extracted step script run against a two-site fixture with mocked curl — confirms multi-site fan-out, header/UA/cache-buster shape, OK path, warning path, and the no-token skip.

## Rollout (after merge)

1. Tag `0.9` / `0.9.0`.
2. Sweep bedrock `cd.yml`s: `@0.8` → `@0.9` and replace the explicit secrets list with `secrets: inherit` (org secrets then flow without being named).
3. Sites start purging once `itineris-opcache-purge` lands in their bedrock repo with the `OPCACHE_PURGE_TOKEN_HASH` config line (plugin PR ItinerisLtd/itineris-opcache-purge#2).
4. The five role-based sites are unaffected throughout — plugin v0.2.0 accepts both auth modes during migration; role + vault cleanup can happen at leisure.

`trellis-deploy-radicle.yml` deliberately untouched (out of scope per Milos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)