### PR TITLE
feat(workflows): add kinsta create-env reusable workflow

### DIFF
--- a/.github/actions/_lib/kinsta-api.sh
+++ b/.github/actions/_lib/kinsta-api.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+poll_kinsta_operation() {
+  local API_URL="$1"
+  local API_KEY="$2"
+  local OPERATION_ID="$3"
+  local MAX_ATTEMPTS="$4"
+  local SLEEP_SECONDS="$5"
+  local OP_FILE="$6"
+
+  local ATTEMPT
+  local HTTP_CODE
+  local BODY_STATUS
+  local BODY_MESSAGE
+  local STATE
+  local LAST_REPORT=''
+  local SERVER_ERRORS=0
+  local MAX_SERVER_ERRORS=5
+  local SEEN_OPERATION='false'
+  local NOT_FOUND_GRACE_ATTEMPTS=8
+
+  sleep "$SLEEP_SECONDS"
+
+  for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT++)); do
+    HTTP_CODE="$(curl --silent --show-error --write-out '%{http_code}' --output "$OP_FILE" \
+      --header "Authorization: Bearer ${API_KEY}" \
+      "$API_URL/operations/$OPERATION_ID")" || true
+
+    BODY_STATUS="$(jq -r 'if (.status | type) == "number" then .status else empty end' "$OP_FILE" 2>/dev/null || true)"
+    BODY_MESSAGE="$(jq -r '.data.message // .message // empty' "$OP_FILE" 2>/dev/null || true)"
+    STATE="${BODY_STATUS:-$HTTP_CODE}"
+
+    if [[ "$LAST_REPORT" != "$STATE $BODY_MESSAGE" ]]; then
+      echo "Operation $OPERATION_ID: http=$HTTP_CODE state=$STATE ${BODY_MESSAGE:+($BODY_MESSAGE)}"
+      LAST_REPORT="$STATE $BODY_MESSAGE"
+    fi
+
+    case "$STATE" in
+      200)
+        echo "Operation $OPERATION_ID finished (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+        return 0
+        ;;
+      202)
+        SEEN_OPERATION='true'
+        SERVER_ERRORS=0
+        ;;
+      500)
+        cat "$OP_FILE" >&2 || true
+        echo "Operation $OPERATION_ID failed: ${BODY_MESSAGE:-no message}" >&2
+        return 1
+        ;;
+      404)
+        if [[ "$SEEN_OPERATION" == "false" && "$ATTEMPT" -le "$NOT_FOUND_GRACE_ATTEMPTS" ]]; then
+          echo "Operation $OPERATION_ID not registered yet (attempt $ATTEMPT/$NOT_FOUND_GRACE_ATTEMPTS)."
+        else
+          cat "$OP_FILE" >&2 || true
+          echo "Operation $OPERATION_ID does not exist or failed on initialization" >&2
+          return 1
+        fi
+        ;;
+      502 | 503 | 504)
+        SERVER_ERRORS=$((SERVER_ERRORS + 1))
+        echo "::warning::Gateway error polling $OPERATION_ID (state $STATE, $SERVER_ERRORS/$MAX_SERVER_ERRORS)" >&2
+        if [[ "$SERVER_ERRORS" -ge "$MAX_SERVER_ERRORS" ]]; then
+          cat "$OP_FILE" >&2 || true
+          echo "Giving up after $SERVER_ERRORS consecutive gateway errors" >&2
+          return 1
+        fi
+        ;;
+      *)
+        cat "$OP_FILE" >&2 || true
+        echo "Unexpected state $STATE polling operation $OPERATION_ID" >&2
+        return 1
+        ;;
+    esac
+
+    sleep "$SLEEP_SECONDS"
+  done
+
+  cat "$OP_FILE" >&2 || true
+  echo "Timed out waiting for operation $OPERATION_ID after $MAX_ATTEMPTS attempts" >&2
+  return 1
+}
+
+wait_for_environment_unblocked() {
+  local API_URL="$1"
+  local API_KEY="$2"
+  local SITE_ID="$3"
+  local ENV_ID="$4"
+  local MAX_ATTEMPTS="$5"
+  local SLEEP_SECONDS="$6"
+  local ENVS_FILE="$7"
+
+  local ATTEMPT
+  local HTTP_CODE
+  local BLOCKED
+
+  for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT++)); do
+    HTTP_CODE="$(curl --silent --show-error --write-out '%{http_code}' --output "$ENVS_FILE" \
+      --header "Authorization: Bearer ${API_KEY}" \
+      "$API_URL/sites/$SITE_ID/environments")" || true
+
+    if [[ "$HTTP_CODE" != "200" ]]; then
+      cat "$ENVS_FILE" >&2 || true
+      echo "Unable to read environments while waiting for $ENV_ID (HTTP $HTTP_CODE)" >&2
+      return 1
+    fi
+
+    BLOCKED="$(jq -r --arg id "$ENV_ID" \
+      '[.site.environments[]? | select(.id == $id) | .is_blocked] | .[0] // false' "$ENVS_FILE")"
+
+    if [[ "$BLOCKED" != "true" ]]; then
+      return 0
+    fi
+
+    echo "Environment $ENV_ID is blocked by another process (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+    sleep "$SLEEP_SECONDS"
+  done
+
+  echo "Timed out waiting for environment $ENV_ID to stop being blocked" >&2
+  return 1
+}
+
+fetch_environments() {
+  local API_URL="$1"
+  local API_KEY="$2"
+  local SITE_ID="$3"
+  local OUT_FILE="$4"
+  local HTTP_CODE
+
+  HTTP_CODE="$(curl --silent --show-error --write-out '%{http_code}' --output "$OUT_FILE" \
+    --header "Authorization: Bearer ${API_KEY}" \
+    "$API_URL/sites/$SITE_ID/environments")" || true
+
+  if [[ "$HTTP_CODE" != "200" ]]; then
+    cat "$OUT_FILE" >&2 || true
+    echo "Unable to read environments for site $SITE_ID (HTTP $HTTP_CODE)" >&2
+    return 1
+  fi
+}
+
+wait_for_primary_domain() {
+  local API_URL="$1"
+  local API_KEY="$2"
+  local SITE_ID="$3"
+  local ENV_ID="$4"
+  local DOMAIN_ID="$5"
+  local MAX_ATTEMPTS="$6"
+  local SLEEP_SECONDS="$7"
+  local ENVS_FILE="$8"
+
+  local ATTEMPT
+  local CURRENT
+
+  for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT++)); do
+    if fetch_environments "$API_URL" "$API_KEY" "$SITE_ID" "$ENVS_FILE"; then
+      CURRENT="$(jq -r --arg env "$ENV_ID" \
+        '[.site.environments[]? | select(.id == $env) | .primaryDomain.id // empty] | .[0] // empty' "$ENVS_FILE")"
+
+      if [[ "$CURRENT" == "$DOMAIN_ID" ]]; then
+        echo "Primary domain confirmed as $DOMAIN_ID (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+        return 0
+      fi
+    fi
+
+    echo "Primary domain not updated yet (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+    sleep "$SLEEP_SECONDS"
+  done
+
+  echo "Primary domain was still not $DOMAIN_ID after $MAX_ATTEMPTS attempts" >&2
+  return 1
+}

--- a/.github/actions/cloudflare-add-records/action.yml
+++ b/.github/actions/cloudflare-add-records/action.yml
@@ -1,0 +1,28 @@
+---
+name: cloudflare-add-records
+description: Add the given DNS records to one Cloudflare zone
+inputs:
+  ZONE_ID:
+    required: true
+  CLOUDFLARE_API_TOKEN:
+    required: true
+  RECORDS_JSON:
+    required: true
+  ADDITIONAL_RECORDS_JSON:
+    description: Extra records to merge, e.g. those Kinsta asks for
+    required: false
+    default: '[]'
+outputs:
+  RECORDS_APPLIED:
+    value: ${{ steps.run.outputs.RECORDS_APPLIED }}
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      run: bash "${{ github.action_path }}/run.sh"
+      env:
+        INPUT_ZONE_ID: ${{ inputs.ZONE_ID }}
+        INPUT_CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
+        INPUT_RECORDS_JSON: ${{ inputs.RECORDS_JSON }}
+        INPUT_ADDITIONAL_RECORDS_JSON: ${{ inputs.ADDITIONAL_RECORDS_JSON }}

--- a/.github/actions/cloudflare-add-records/run.sh
+++ b/.github/actions/cloudflare-add-records/run.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLOUDFLARE_TOKEN="${INPUT_CLOUDFLARE_API_TOKEN:-}"
+ZONE_ID="${INPUT_ZONE_ID:-}"
+RECORDS_JSON="${INPUT_RECORDS_JSON:-}"
+
+if [[ -z "$CLOUDFLARE_TOKEN" ]]; then
+  echo "Missing INPUT_CLOUDFLARE_API_TOKEN" >&2
+  exit 2
+fi
+
+if [[ -z "$ZONE_ID" ]]; then
+  echo "Missing INPUT_ZONE_ID. Pass the CLOUDFLARE_ZONE_ID_DEV secret." >&2
+  exit 2
+fi
+
+if [[ -z "$RECORDS_JSON" ]]; then
+  echo "Missing INPUT_RECORDS_JSON" >&2
+  exit 2
+fi
+
+if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$RECORDS_JSON"; then
+  echo "INPUT_RECORDS_JSON must be a JSON array" >&2
+  exit 2
+fi
+
+ADDITIONAL_RECORDS_JSON="${INPUT_ADDITIONAL_RECORDS_JSON:-[]}"
+
+if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$ADDITIONAL_RECORDS_JSON"; then
+  echo "INPUT_ADDITIONAL_RECORDS_JSON must be a JSON array" >&2
+  exit 2
+fi
+
+RECORDS_JSON="$(jq -c -n --argjson a "$RECORDS_JSON" --argjson b "$ADDITIONAL_RECORDS_JSON" '
+  ($a + ($b | map(select(. as $r | ($a | any(.name == $r.name)) | not))))
+  | unique_by([.name, .type, (.value // .content), (.proxied // false)])
+')"
+
+DROPPED="$(jq -n --argjson a "$RECORDS_JSON" --argjson b "$ADDITIONAL_RECORDS_JSON" \
+  '[$b[] | select(. as $r | ($a | any(.name == $r.name and .type == $r.type)) | not) | "\(.type) \(.name)"] | join(", ")')"
+
+if [[ -n "$DROPPED" && "$DROPPED" != "null" ]]; then
+  echo "Superseded by the constructed pointing record: $DROPPED"
+fi
+
+AUTH_HEADER="Authorization: Bearer ${CLOUDFLARE_TOKEN}"
+ZONE_API="https://api.cloudflare.com/client/v4/zones/$ZONE_ID"
+
+ZONE_RESP="$(curl --silent --show-error --fail --header "$AUTH_HEADER" "$ZONE_API")"
+ZONE_NAME="$(jq -r '.result.name // empty' <<<"$ZONE_RESP")"
+
+if [[ -z "$ZONE_NAME" ]]; then
+  echo "Unable to resolve the zone name for $ZONE_ID" >&2
+  exit 3
+fi
+
+fqdn() {
+  local NAME="${1%.}"
+
+  if [[ "$NAME" == "@" || -z "$NAME" ]]; then
+    printf '%s' "$ZONE_NAME"
+    return 0
+  fi
+
+  if [[ "$NAME" == "$ZONE_NAME" || "$NAME" == *".$ZONE_NAME" ]]; then
+    printf '%s' "$NAME"
+    return 0
+  fi
+
+  printf '%s.%s' "$NAME" "$ZONE_NAME"
+}
+
+record_payload() {
+  jq -n \
+    --arg type "$1" \
+    --arg name "$2" \
+    --arg content "$3" \
+    --argjson proxied "$4" \
+    '{type: $type, name: $name, content: $content, ttl: 1, proxied: $proxied}'
+}
+
+APPLIED=0
+while IFS= read -r ROW; do
+  RECORD_NAME="$(jq -r '.name // empty' <<<"$ROW")"
+  RECORD_TYPE="$(jq -r '.type // empty' <<<"$ROW")"
+  RECORD_CONTENT="$(jq -r '.value // .content // empty' <<<"$ROW")"
+  PROXIED="$(jq -r 'if .proxied == true then "true" else "false" end' <<<"$ROW")"
+
+  if [[ -z "$RECORD_NAME" || -z "$RECORD_TYPE" || -z "$RECORD_CONTENT" ]]; then
+    echo "Skipping malformed record: $ROW" >&2
+    continue
+  fi
+
+  RECORD_NAME="$(fqdn "$RECORD_NAME")"
+  RECORD_TYPE="$(tr '[:lower:]' '[:upper:]' <<<"$RECORD_TYPE")"
+  QUERY_NAME="$(jq -rn --arg v "$RECORD_NAME" '$v | @uri')"
+  QUERY_TYPE="$(jq -rn --arg v "$RECORD_TYPE" '$v | @uri')"
+
+  QUERY_RESP="$(curl --silent --show-error --fail \
+    --header "$AUTH_HEADER" \
+    "$ZONE_API/dns_records?type=$QUERY_TYPE&name=$QUERY_NAME")"
+
+  EXACT_COUNT="$(jq -r --arg content "$RECORD_CONTENT" --argjson proxied "$PROXIED" \
+    '[.result[] | select(.content == $content and (.proxied // false) == $proxied)] | length' <<<"$QUERY_RESP")"
+  CANDIDATE_COUNT="$(jq -r '.result | length' <<<"$QUERY_RESP")"
+
+  if [[ "$EXACT_COUNT" -gt 0 ]]; then
+    echo "$RECORD_TYPE $RECORD_NAME already points at $RECORD_CONTENT (proxied=$PROXIED)."
+    continue
+  fi
+
+  PAYLOAD="$(record_payload "$RECORD_TYPE" "$RECORD_NAME" "$RECORD_CONTENT" "$PROXIED")"
+  RECORD_ID=''
+
+  if [[ "$RECORD_TYPE" != "TXT" && "$RECORD_TYPE" != "MX" && "$RECORD_TYPE" != "SRV" && "$RECORD_TYPE" != "CAA" ]]; then
+    RECORD_ID="$(jq -r '.result[0].id // empty' <<<"$QUERY_RESP")"
+  fi
+
+  if [[ -n "$RECORD_ID" ]]; then
+    OLD_CONTENT="$(jq -r '.result[0].content // empty' <<<"$QUERY_RESP")"
+    echo "Updating $RECORD_TYPE $RECORD_NAME: '$OLD_CONTENT' -> '$RECORD_CONTENT' (proxied=$PROXIED)"
+
+    curl --silent --show-error --fail \
+      --request PUT \
+      --header "$AUTH_HEADER" \
+      --header "Content-Type: application/json" \
+      --data "$PAYLOAD" \
+      "$ZONE_API/dns_records/$RECORD_ID" >/dev/null
+  else
+    echo "Creating $RECORD_TYPE $RECORD_NAME -> $RECORD_CONTENT (proxied=$PROXIED)"
+
+    if [[ "$CANDIDATE_COUNT" -gt 0 ]]; then
+      echo "::warning::$RECORD_TYPE $RECORD_NAME already has $CANDIDATE_COUNT record(s) with other values; review for stale entries."
+    fi
+
+    curl --silent --show-error --fail \
+      --request POST \
+      --header "$AUTH_HEADER" \
+      --header "Content-Type: application/json" \
+      --data "$PAYLOAD" \
+      "$ZONE_API/dns_records" >/dev/null
+  fi
+
+  APPLIED=$((APPLIED + 1))
+done < <(jq -c '.[]' <<<"$RECORDS_JSON")
+
+echo "RECORDS_APPLIED=$APPLIED" >> "$GITHUB_OUTPUT"

--- a/.github/actions/kinsta-attach-domain/action.yml
+++ b/.github/actions/kinsta-attach-domain/action.yml
@@ -1,0 +1,38 @@
+---
+name: kinsta-attach-domain
+description: Attach the project hostname and emit its pointing record
+inputs:
+  SITE_ID:
+    required: true
+  ENVIRONMENT_ID:
+    required: true
+  REPOSITORY:
+    description: Caller repository in owner/name form
+    required: true
+  BASE_DOMAIN:
+    description: Zone the derived project hostname is created under
+    required: true
+  KINSTA_API_URL:
+    required: true
+  KINSTA_API_KEY:
+    required: true
+outputs:
+  RECORDS_JSON:
+    value: ${{ steps.run.outputs.RECORDS_JSON }}
+  PRIMARY_DOMAIN:
+    value: ${{ steps.run.outputs.PRIMARY_DOMAIN }}
+  DOMAIN_ID:
+    value: ${{ steps.run.outputs.DOMAIN_ID }}
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      run: bash "${{ github.action_path }}/run.sh"
+      env:
+        INPUT_SITE_ID: ${{ inputs.SITE_ID }}
+        INPUT_ENVIRONMENT_ID: ${{ inputs.ENVIRONMENT_ID }}
+        INPUT_REPOSITORY: ${{ inputs.REPOSITORY }}
+        INPUT_BASE_DOMAIN: ${{ inputs.BASE_DOMAIN }}
+        INPUT_KINSTA_API_URL: ${{ inputs.KINSTA_API_URL }}
+        INPUT_KINSTA_API_KEY: ${{ inputs.KINSTA_API_KEY }}

--- a/.github/actions/kinsta-attach-domain/run.sh
+++ b/.github/actions/kinsta-attach-domain/run.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=../_lib/kinsta-api.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/kinsta-api.sh"
+
+SITE_ID="${INPUT_SITE_ID:-}"
+ENVIRONMENT_ID="${INPUT_ENVIRONMENT_ID:-}"
+REPOSITORY="${INPUT_REPOSITORY:-}"
+BASE_DOMAIN="${INPUT_BASE_DOMAIN:-}"
+KINSTA_API_URL="${INPUT_KINSTA_API_URL:-}"
+KINSTA_TOKEN="${INPUT_KINSTA_API_KEY:-}"
+
+if [[ -z "$SITE_ID" || -z "$ENVIRONMENT_ID" || -z "$REPOSITORY" || -z "$BASE_DOMAIN" || -z "$KINSTA_API_URL" || -z "$KINSTA_TOKEN" ]]; then
+  echo "Missing required input(s) for domain attachment" >&2
+  exit 2
+fi
+
+PROJECT_NAME="${REPOSITORY##*/}"
+PROJECT_NAME="${PROJECT_NAME%-bedrock}"
+PROJECT_NAME="${PROJECT_NAME%-trellis}"
+PROJECT_NAME="${PROJECT_NAME%-radicle}"
+PROJECT_NAME="${PROJECT_NAME#www.}"
+PROJECT_NAME="${PROJECT_NAME%%.*}"
+PROJECT_NAME="$(tr '[:upper:]' '[:lower:]' <<<"$PROJECT_NAME")"
+
+if ! [[ "$PROJECT_NAME" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+  echo "Could not derive a valid hostname label from repository '$REPOSITORY'" >&2
+  exit 3
+fi
+
+PRIMARY_DOMAIN="$PROJECT_NAME.$BASE_DOMAIN"
+echo "Derived primary domain: $PRIMARY_DOMAIN"
+
+KINSTA_AUTH_HEADER="Authorization: Bearer ${KINSTA_TOKEN}"
+SCRATCH_DIR="${RUNNER_TEMP:?RUNNER_TEMP is not set}"
+DOMAINS_FILE="$SCRATCH_DIR/kinsta-domains.json"
+CREATE_FILE="$SCRATCH_DIR/kinsta-domain-create.json"
+OP_FILE="$SCRATCH_DIR/kinsta-domain-op.json"
+
+lookup_domain_id() {
+  local STATUS_CODE
+
+  STATUS_CODE="$(curl --silent --show-error --write-out '%{http_code}' --output "$DOMAINS_FILE" \
+    --header "$KINSTA_AUTH_HEADER" \
+    "$KINSTA_API_URL/sites/environments/$ENVIRONMENT_ID/domains")" || true
+
+  if [[ "$STATUS_CODE" != "200" ]]; then
+    cat "$DOMAINS_FILE" >&2 || true
+    echo "Unable to list domains for environment $ENVIRONMENT_ID (HTTP $STATUS_CODE)" >&2
+    exit 4
+  fi
+
+  jq -r --arg name "$PRIMARY_DOMAIN" \
+    '[.environment.site_domains[]? | select(.name == $name) | .id] | .[0] // empty' "$DOMAINS_FILE"
+}
+
+DOMAIN_ID="$(lookup_domain_id)"
+
+if [[ -n "$DOMAIN_ID" ]]; then
+  echo "Domain '$PRIMARY_DOMAIN' is already attached."
+else
+  ENVS_FILE="$SCRATCH_DIR/kinsta-envs.json"
+
+  if ! fetch_environments "$KINSTA_API_URL" "$KINSTA_TOKEN" "$SITE_ID" "$ENVS_FILE"; then
+    exit 9
+  fi
+
+  OTHER_ENV="$(jq -r --arg name "$PRIMARY_DOMAIN" --arg env "$ENVIRONMENT_ID" '
+    [ .site.environments[]?
+      | select(.id != $env)
+      | select(any(.domains[]?; .name == $name))
+      | .name
+    ] | .[0] // empty
+  ' "$ENVS_FILE")"
+
+  if [[ -n "$OTHER_ENV" ]]; then
+    echo "Domain '$PRIMARY_DOMAIN' is already attached to the '$OTHER_ENV' environment of this site." >&2
+    echo "Detach it there first, or the environments will contend for the same hostname." >&2
+    exit 10
+  fi
+
+  if ! wait_for_environment_unblocked "$KINSTA_API_URL" "$KINSTA_TOKEN" "$SITE_ID" \
+    "$ENVIRONMENT_ID" 60 15 "$SCRATCH_DIR/kinsta-envs-blocked.json"; then
+    exit 8
+  fi
+
+  PAYLOAD="$(jq -n --arg domain_name "$PRIMARY_DOMAIN" \
+    '{domain_name: $domain_name, setup_type: "quick"}')"
+
+  STATUS_CODE="$(curl --silent --show-error --write-out '%{http_code}' --output "$CREATE_FILE" \
+    --request POST \
+    --header "$KINSTA_AUTH_HEADER" \
+    --header "Content-Type: application/json" \
+    --data "$PAYLOAD" \
+    "$KINSTA_API_URL/sites/environments/$ENVIRONMENT_ID/domains")" || true
+
+  if [[ "$STATUS_CODE" != "202" && "$STATUS_CODE" != "200" && "$STATUS_CODE" != "201" ]]; then
+    cat "$CREATE_FILE" >&2 || true
+    echo "Unable to add domain '$PRIMARY_DOMAIN' (HTTP $STATUS_CODE)" >&2
+    exit 5
+  fi
+
+  OPERATION_ID="$(jq -r '.operation_id // empty' "$CREATE_FILE")"
+
+  if [[ -n "$OPERATION_ID" ]] && ! poll_kinsta_operation \
+    "$KINSTA_API_URL" "$KINSTA_TOKEN" "$OPERATION_ID" 40 15 "$OP_FILE"; then
+    exit 6
+  fi
+
+  for ((ATTEMPT = 1; ATTEMPT <= 10; ATTEMPT++)); do
+    DOMAIN_ID="$(lookup_domain_id)"
+
+    if [[ -n "$DOMAIN_ID" ]]; then
+      break
+    fi
+
+    echo "Domain '$PRIMARY_DOMAIN' not listed yet (attempt $ATTEMPT/10)."
+    sleep 15
+  done
+fi
+
+if [[ -z "$DOMAIN_ID" ]]; then
+  echo "Unable to resolve domain id for '$PRIMARY_DOMAIN'" >&2
+  jq -c '[.environment.site_domains[]? | {id, name}]' "$DOMAINS_FILE" >&2 || true
+  exit 7
+fi
+
+POINTING_TARGET="$PROJECT_NAME.hosting.kinsta.cloud"
+
+RECORDS_JSON="$(jq -n -c \
+  --arg name "$PRIMARY_DOMAIN" \
+  --arg value "$POINTING_TARGET" \
+  '[{name: $name, type: "CNAME", value: $value, proxied: true}]')"
+
+echo "Pointing record: $PRIMARY_DOMAIN CNAME $POINTING_TARGET"
+
+if ! wait_for_environment_unblocked "$KINSTA_API_URL" "$KINSTA_TOKEN" "$SITE_ID" \
+  "$ENVIRONMENT_ID" 60 15 "$SCRATCH_DIR/kinsta-envs-blocked.json"; then
+  exit 11
+fi
+
+{
+  echo "PRIMARY_DOMAIN=$PRIMARY_DOMAIN"
+  echo "DOMAIN_ID=$DOMAIN_ID"
+  echo "RECORDS_JSON=$RECORDS_JSON"
+} >> "$GITHUB_OUTPUT"

--- a/.github/actions/kinsta-collect-dns-records/action.yml
+++ b/.github/actions/kinsta-collect-dns-records/action.yml
@@ -1,0 +1,38 @@
+---
+name: kinsta-collect-dns-records
+description: Collect the DNS records Kinsta wants, and whether any are needed
+inputs:
+  DOMAIN_ID:
+    required: true
+  PRIMARY_DOMAIN:
+    description: Hostname to test for existing resolution
+    required: true
+  KINSTA_API_URL:
+    required: true
+  KINSTA_API_KEY:
+    required: true
+  MAX_ATTEMPTS:
+    required: false
+    default: '8'
+  SLEEP_SECONDS:
+    required: false
+    default: '15'
+outputs:
+  RECORDS_JSON:
+    value: ${{ steps.run.outputs.RECORDS_JSON }}
+  DNS_READY:
+    description: Whether the DNS record already exists, so none need adding
+    value: ${{ steps.run.outputs.DNS_READY }}
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      run: bash "${{ github.action_path }}/run.sh"
+      env:
+        INPUT_DOMAIN_ID: ${{ inputs.DOMAIN_ID }}
+        INPUT_PRIMARY_DOMAIN: ${{ inputs.PRIMARY_DOMAIN }}
+        INPUT_KINSTA_API_URL: ${{ inputs.KINSTA_API_URL }}
+        INPUT_KINSTA_API_KEY: ${{ inputs.KINSTA_API_KEY }}
+        INPUT_MAX_ATTEMPTS: ${{ inputs.MAX_ATTEMPTS }}
+        INPUT_SLEEP_SECONDS: ${{ inputs.SLEEP_SECONDS }}

--- a/.github/actions/kinsta-collect-dns-records/run.sh
+++ b/.github/actions/kinsta-collect-dns-records/run.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN_ID="${INPUT_DOMAIN_ID:-}"
+PRIMARY_DOMAIN="${INPUT_PRIMARY_DOMAIN:-}"
+KINSTA_API_URL="${INPUT_KINSTA_API_URL:-}"
+KINSTA_API_KEY="${INPUT_KINSTA_API_KEY:-}"
+MAX_ATTEMPTS="${INPUT_MAX_ATTEMPTS:-8}"
+SLEEP_SECONDS="${INPUT_SLEEP_SECONDS:-15}"
+
+if [[ -z "$DOMAIN_ID" || -z "$KINSTA_API_URL" || -z "$KINSTA_API_KEY" ]]; then
+  echo "Missing required input(s) for DNS record collection" >&2
+  exit 2
+fi
+
+if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || ! [[ "$SLEEP_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "MAX_ATTEMPTS and SLEEP_SECONDS must be integers" >&2
+  exit 2
+fi
+
+if [[ "$MAX_ATTEMPTS" -lt 1 || "$SLEEP_SECONDS" -lt 1 ]]; then
+  echo "MAX_ATTEMPTS and SLEEP_SECONDS must be greater than zero" >&2
+  exit 2
+fi
+
+KINSTA_AUTH_HEADER="Authorization: Bearer ${KINSTA_API_KEY}"
+RECORDS_FILE="${RUNNER_TEMP:?RUNNER_TEMP is not set}/kinsta-dns-records.json"
+
+records_json() {
+  jq -c '
+    ((.site_domain.verification_records // []) | map(. + {proxied: false}))
+    + ((.site_domain.pointing_records // []) | map(. + {proxied: true}))
+  ' "$RECORDS_FILE"
+}
+
+fetch_records() {
+  local STATUS_CODE
+
+  STATUS_CODE="$(curl --silent --show-error --write-out '%{http_code}' --output "$RECORDS_FILE" \
+    --header "$KINSTA_AUTH_HEADER" \
+    "$KINSTA_API_URL/sites/environments/domains/$DOMAIN_ID/verification-records")" || true
+
+  if [[ "$STATUS_CODE" == "401" || "$STATUS_CODE" == "403" || "$STATUS_CODE" == "404" ]]; then
+    cat "$RECORDS_FILE" >&2 || true
+    echo "Kinsta DNS record lookup failed with HTTP $STATUS_CODE" >&2
+    exit 3
+  fi
+
+  [[ "$STATUS_CODE" == "200" ]]
+}
+
+if fetch_records; then
+  echo "Kinsta reports: $(jq -c '.' "$RECORDS_FILE")"
+fi
+
+if [[ -n "$PRIMARY_DOMAIN" ]] && getent hosts "$PRIMARY_DOMAIN" >/dev/null 2>&1; then
+  echo "$PRIMARY_DOMAIN already resolves, so its DNS record is in place."
+  {
+    echo "RECORDS_JSON=[]"
+    echo "DNS_READY=true"
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
+  if fetch_records; then
+    POINTING_COUNT="$(jq -r '(.site_domain.pointing_records // []) | length' "$RECORDS_FILE")"
+
+    if [[ "$POINTING_COUNT" -gt 0 ]]; then
+      {
+        echo "RECORDS_JSON=$(records_json)"
+        echo "DNS_READY=false"
+      } >> "$GITHUB_OUTPUT"
+      echo "Collected $POINTING_COUNT pointing record(s) from Kinsta."
+      exit 0
+    fi
+  fi
+
+  if [[ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]]; then
+    echo "No records from Kinsta yet (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+    sleep "$SLEEP_SECONDS"
+  fi
+done
+
+echo "::warning::Kinsta returned no DNS records and ${PRIMARY_DOMAIN:-the hostname} does not resolve."
+echo "Falling back to the constructed pointing record."
+{
+  echo "RECORDS_JSON=[]"
+  echo "DNS_READY=false"
+} >> "$GITHUB_OUTPUT"
+exit 0

--- a/.github/actions/kinsta-find-or-create-env/action.yml
+++ b/.github/actions/kinsta-find-or-create-env/action.yml
@@ -1,0 +1,31 @@
+---
+name: kinsta-find-or-create-env
+description: Find the target Kinsta environment, cloning it when it is missing
+inputs:
+  SITE_ID:
+    required: true
+  TARGET_ENVIRONMENT:
+    required: true
+  SOURCE_ENVIRONMENT:
+    required: true
+  KINSTA_API_URL:
+    required: true
+  KINSTA_API_KEY:
+    required: true
+outputs:
+  CREATED:
+    value: ${{ steps.run.outputs.CREATED }}
+  ENVIRONMENT_ID:
+    value: ${{ steps.run.outputs.ENVIRONMENT_ID }}
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      run: bash "${{ github.action_path }}/run.sh"
+      env:
+        INPUT_SITE_ID: ${{ inputs.SITE_ID }}
+        INPUT_TARGET_ENVIRONMENT: ${{ inputs.TARGET_ENVIRONMENT }}
+        INPUT_SOURCE_ENVIRONMENT: ${{ inputs.SOURCE_ENVIRONMENT }}
+        INPUT_KINSTA_API_URL: ${{ inputs.KINSTA_API_URL }}
+        INPUT_KINSTA_API_KEY: ${{ inputs.KINSTA_API_KEY }}

--- a/.github/actions/kinsta-find-or-create-env/run.sh
+++ b/.github/actions/kinsta-find-or-create-env/run.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=../_lib/kinsta-api.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/kinsta-api.sh"
+
+TARGET_ENV="${INPUT_TARGET_ENVIRONMENT:-}"
+SITE_ID="${INPUT_SITE_ID:-}"
+API_URL="${INPUT_KINSTA_API_URL:-}"
+API_KEY="${INPUT_KINSTA_API_KEY:-}"
+
+if [[ -z "$TARGET_ENV" || -z "$SITE_ID" || -z "$API_URL" || -z "$API_KEY" ]]; then
+  echo "Missing required input(s)" >&2
+  exit 2
+fi
+
+SCRATCH_DIR="${RUNNER_TEMP:?RUNNER_TEMP is not set}"
+OP_JSON_FILE="$SCRATCH_DIR/kinsta-op.json"
+
+if [[ "$(tr '[:upper:]' '[:lower:]' <<<"$TARGET_ENV")" == \
+      "$(tr '[:upper:]' '[:lower:]' <<<"${INPUT_SOURCE_ENVIRONMENT:-live}")" ]]; then
+  echo "Target and source environment are both '$TARGET_ENV'." >&2
+  echo "Refusing to reconfigure the source environment in place." >&2
+  exit 13
+fi
+
+KINSTA_AUTH_HEADER=("Authorization: Bearer ${API_KEY}")
+KINSTA_CT_HEADER=("Content-Type: application/json")
+
+get_envs() {
+  curl --silent --show-error --fail \
+    --header "${KINSTA_AUTH_HEADER[0]}" \
+    --header "${KINSTA_CT_HEADER[0]}" \
+    "$API_URL/sites/$SITE_ID/environments"
+}
+
+ENVS_JSON="$(get_envs)"
+
+TARGET_ID="$(jq -r --arg n "$TARGET_ENV" '.site.environments[] | select((.name | ascii_downcase) == ($n | ascii_downcase) or (.display_name | ascii_downcase) == ($n | ascii_downcase)) | .id' <<<"$ENVS_JSON" | head -n1)"
+
+CREATED='false'
+
+if [[ -z "${TARGET_ID:-}" || "$TARGET_ID" == "null" ]]; then
+  SOURCE_ENV="${INPUT_SOURCE_ENVIRONMENT:-live}"
+  SOURCE_ID="$(jq -r --arg n "$SOURCE_ENV" '.site.environments[] | select((.name | ascii_downcase) == ($n | ascii_downcase) or (.display_name | ascii_downcase) == ($n | ascii_downcase)) | .id' <<<"$ENVS_JSON" | head -n1)"
+
+  if [[ -z "${SOURCE_ID:-}" || "$SOURCE_ID" == "null" ]]; then
+    echo "Source environment '$SOURCE_ENV' not found on site $SITE_ID" >&2
+    exit 3
+  fi
+
+  DISPLAY_NAME="$(tr '[:lower:]' '[:upper:]' <<<"${TARGET_ENV:0:1}")${TARGET_ENV:1}"
+
+  CLONE_PAYLOAD="$(jq -n --arg dn "$DISPLAY_NAME" --arg sid "$SOURCE_ID" \
+    '{display_name: $dn, is_premium: false, source_env_id: $sid}')"
+
+  CLONE_RESP="$(curl --silent --show-error --fail \
+    --request POST \
+    --header "${KINSTA_AUTH_HEADER[0]}" \
+    --header "${KINSTA_CT_HEADER[0]}" \
+    --data "$CLONE_PAYLOAD" \
+    "$API_URL/sites/$SITE_ID/environments/clone")"
+
+  OPERATION_ID="$(jq -r '.operation_id // empty' <<<"$CLONE_RESP")"
+  if [[ -z "${OPERATION_ID:-}" ]]; then
+    echo "Clone request did not return operation_id" >&2
+    echo "Response: $CLONE_RESP" >&2
+    exit 4
+  fi
+
+  if ! poll_kinsta_operation "$API_URL" "$API_KEY" "$OPERATION_ID" 80 15 "$OP_JSON_FILE"; then
+    exit 5
+  fi
+
+  for ((LOOKUP = 1; LOOKUP <= 10; LOOKUP++)); do
+    ENVS_JSON="$(get_envs)"
+    TARGET_ID="$(jq -r --arg n "$TARGET_ENV" '.site.environments[] | select((.name | ascii_downcase) == ($n | ascii_downcase) or (.display_name | ascii_downcase) == ($n | ascii_downcase)) | .id' <<<"$ENVS_JSON" | head -n1)"
+
+    if [[ -n "${TARGET_ID:-}" && "$TARGET_ID" != "null" ]]; then
+      break
+    fi
+
+    echo "Cloned environment '$TARGET_ENV' not listed yet (attempt $LOOKUP/10)."
+    sleep 15
+  done
+
+  if [[ -z "${TARGET_ID:-}" || "$TARGET_ID" == "null" ]]; then
+    echo "Environment created but id not found after operation" >&2
+    jq -c '[.site.environments[] | {id, name, display_name}]' <<<"$ENVS_JSON" >&2 || true
+    exit 8
+  fi
+  CREATED='true'
+fi
+
+if ! wait_for_environment_unblocked "$API_URL" "$API_KEY" "$SITE_ID" "$TARGET_ID" 60 15 \
+  "$SCRATCH_DIR/kinsta-envs-blocked.json"; then
+  exit 12
+fi
+
+{
+  printf 'CREATED=%s\n' "$CREATED"
+  printf 'ENVIRONMENT_ID=%s\n' "$TARGET_ID"
+} >> "$GITHUB_OUTPUT"
+
+exit 0

--- a/.github/actions/kinsta-set-primary-domain/action.yml
+++ b/.github/actions/kinsta-set-primary-domain/action.yml
@@ -1,0 +1,37 @@
+---
+name: kinsta-set-primary-domain
+description: Promote a domain to primary and search-replace the database URLs
+inputs:
+  SITE_ID:
+    required: true
+  ENVIRONMENT_ID:
+    required: true
+  DOMAIN_ID:
+    required: true
+  RUN_SEARCH_AND_REPLACE:
+    required: false
+    default: 'true'
+  KINSTA_API_URL:
+    required: true
+  KINSTA_API_KEY:
+    required: true
+  MAX_ATTEMPTS:
+    required: false
+    default: '40'
+  SLEEP_SECONDS:
+    required: false
+    default: '15'
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: bash "${{ github.action_path }}/run.sh"
+      env:
+        INPUT_SITE_ID: ${{ inputs.SITE_ID }}
+        INPUT_ENVIRONMENT_ID: ${{ inputs.ENVIRONMENT_ID }}
+        INPUT_DOMAIN_ID: ${{ inputs.DOMAIN_ID }}
+        INPUT_RUN_SEARCH_AND_REPLACE: ${{ inputs.RUN_SEARCH_AND_REPLACE }}
+        INPUT_KINSTA_API_URL: ${{ inputs.KINSTA_API_URL }}
+        INPUT_KINSTA_API_KEY: ${{ inputs.KINSTA_API_KEY }}
+        INPUT_MAX_ATTEMPTS: ${{ inputs.MAX_ATTEMPTS }}
+        INPUT_SLEEP_SECONDS: ${{ inputs.SLEEP_SECONDS }}

--- a/.github/actions/kinsta-set-primary-domain/run.sh
+++ b/.github/actions/kinsta-set-primary-domain/run.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=../_lib/kinsta-api.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/kinsta-api.sh"
+
+SITE_ID="${INPUT_SITE_ID:-}"
+ENVIRONMENT_ID="${INPUT_ENVIRONMENT_ID:-}"
+DOMAIN_ID="${INPUT_DOMAIN_ID:-}"
+KINSTA_API_URL="${INPUT_KINSTA_API_URL:-}"
+KINSTA_API_KEY="${INPUT_KINSTA_API_KEY:-}"
+RUN_SEARCH_AND_REPLACE="${INPUT_RUN_SEARCH_AND_REPLACE:-true}"
+MAX_ATTEMPTS="${INPUT_MAX_ATTEMPTS:-40}"
+SLEEP_SECONDS="${INPUT_SLEEP_SECONDS:-15}"
+
+if [[ -z "$SITE_ID" || -z "$ENVIRONMENT_ID" || -z "$DOMAIN_ID" || -z "$KINSTA_API_URL" || -z "$KINSTA_API_KEY" ]]; then
+  echo "Missing required input(s) for primary domain assignment" >&2
+  exit 2
+fi
+
+if [[ "$RUN_SEARCH_AND_REPLACE" != "true" && "$RUN_SEARCH_AND_REPLACE" != "false" ]]; then
+  echo "RUN_SEARCH_AND_REPLACE must be 'true' or 'false'" >&2
+  exit 2
+fi
+
+if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || ! [[ "$SLEEP_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "MAX_ATTEMPTS and SLEEP_SECONDS must be integers" >&2
+  exit 2
+fi
+
+if [[ "$MAX_ATTEMPTS" -lt 1 || "$SLEEP_SECONDS" -lt 1 ]]; then
+  echo "MAX_ATTEMPTS and SLEEP_SECONDS must be greater than zero" >&2
+  exit 2
+fi
+
+KINSTA_AUTH_HEADER="Authorization: Bearer ${KINSTA_API_KEY}"
+SCRATCH_DIR="${RUNNER_TEMP:?RUNNER_TEMP is not set}"
+CHANGE_FILE="$SCRATCH_DIR/kinsta-primary-domain.json"
+OP_FILE="$SCRATCH_DIR/kinsta-primary-domain-op.json"
+
+ENVS_FILE="$SCRATCH_DIR/kinsta-envs.json"
+
+if ! fetch_environments "$KINSTA_API_URL" "$KINSTA_API_KEY" "$SITE_ID" "$ENVS_FILE"; then
+  exit 8
+fi
+
+CURRENT_PRIMARY_ID="$(jq -r --arg env "$ENVIRONMENT_ID" \
+  '[.site.environments[]? | select(.id == $env) | .primaryDomain.id // empty] | .[0] // empty' "$ENVS_FILE")"
+
+if [[ "$CURRENT_PRIMARY_ID" == "$DOMAIN_ID" ]]; then
+  echo "Domain $DOMAIN_ID is already the primary domain; nothing to do."
+  exit 0
+fi
+
+if ! wait_for_environment_unblocked "$KINSTA_API_URL" "$KINSTA_API_KEY" "$SITE_ID" \
+  "$ENVIRONMENT_ID" 60 15 "$SCRATCH_DIR/kinsta-envs-blocked.json"; then
+  exit 7
+fi
+
+PAYLOAD="$(jq -n \
+  --arg domain_id "$DOMAIN_ID" \
+  --argjson run_search_and_replace "$RUN_SEARCH_AND_REPLACE" \
+  '{domain_id: $domain_id, run_search_and_replace: $run_search_and_replace}')"
+
+STATUS_CODE="$(curl --silent --show-error --write-out '%{http_code}' --output "$CHANGE_FILE" \
+  --request PUT \
+  --header "$KINSTA_AUTH_HEADER" \
+  --header "Content-Type: application/json" \
+  --data "$PAYLOAD" \
+  "$KINSTA_API_URL/sites/environments/$ENVIRONMENT_ID/change-primary-domain")" || true
+
+if [[ "$STATUS_CODE" != "202" && "$STATUS_CODE" != "200" ]]; then
+  cat "$CHANGE_FILE" >&2 || true
+  echo "Failed to set primary domain $DOMAIN_ID (HTTP $STATUS_CODE)" >&2
+  exit 3
+fi
+
+OPERATION_ID="$(jq -r '.operation_id // empty' "$CHANGE_FILE")"
+if [[ -z "$OPERATION_ID" ]]; then
+  echo "Primary domain set without an operation to poll."
+  exit 0
+fi
+
+if ! poll_kinsta_operation "$KINSTA_API_URL" "$KINSTA_API_KEY" "$OPERATION_ID" \
+  "$MAX_ATTEMPTS" "$SLEEP_SECONDS" "$OP_FILE"; then
+  exit 4
+fi
+
+if ! wait_for_primary_domain "$KINSTA_API_URL" "$KINSTA_API_KEY" "$SITE_ID" \
+  "$ENVIRONMENT_ID" "$DOMAIN_ID" "$MAX_ATTEMPTS" "$SLEEP_SECONDS" "$ENVS_FILE"; then
+  exit 5
+fi
+
+if ! wait_for_environment_unblocked "$KINSTA_API_URL" "$KINSTA_API_KEY" "$SITE_ID" \
+  "$ENVIRONMENT_ID" 60 15 "$SCRATCH_DIR/kinsta-envs-blocked.json"; then
+  exit 6
+fi
+
+echo "Primary domain set and search-replace finished."

--- a/.github/actions/kinsta-ssh-details/action.yml
+++ b/.github/actions/kinsta-ssh-details/action.yml
@@ -1,0 +1,33 @@
+---
+name: kinsta-ssh-details
+description: Read the SSH connection details for an environment
+inputs:
+  SITE_ID:
+    required: true
+  ENVIRONMENT_ID:
+    required: true
+  ENVIRONMENT:
+    required: true
+  KINSTA_API_URL:
+    required: true
+  KINSTA_API_KEY:
+    required: true
+outputs:
+  SSH_USER:
+    value: ${{ steps.run.outputs.SSH_USER }}
+  SSH_HOST:
+    value: ${{ steps.run.outputs.SSH_HOST }}
+  SSH_PORT:
+    value: ${{ steps.run.outputs.SSH_PORT }}
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      run: bash "${{ github.action_path }}/run.sh"
+      env:
+        INPUT_SITE_ID: ${{ inputs.SITE_ID }}
+        INPUT_ENVIRONMENT_ID: ${{ inputs.ENVIRONMENT_ID }}
+        INPUT_ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
+        INPUT_KINSTA_API_URL: ${{ inputs.KINSTA_API_URL }}
+        INPUT_KINSTA_API_KEY: ${{ inputs.KINSTA_API_KEY }}

--- a/.github/actions/kinsta-ssh-details/run.sh
+++ b/.github/actions/kinsta-ssh-details/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SITE_ID="${INPUT_SITE_ID:-}"
+ENVIRONMENT_ID="${INPUT_ENVIRONMENT_ID:-}"
+ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
+KINSTA_API_URL="${INPUT_KINSTA_API_URL:-}"
+KINSTA_API_KEY="${INPUT_KINSTA_API_KEY:-}"
+
+if [[ -z "$SITE_ID" || -z "$ENVIRONMENT_ID" || -z "$ENVIRONMENT" || -z "$KINSTA_API_URL" || -z "$KINSTA_API_KEY" ]]; then
+  echo "Missing required input(s) for SSH details" >&2
+  exit 2
+fi
+
+CONFIG_FILE="${RUNNER_TEMP:?RUNNER_TEMP is not set}/kinsta-ssh-config.json"
+
+STATUS_CODE="$(curl --silent --show-error --write-out '%{http_code}' --output "$CONFIG_FILE" \
+  --header "Authorization: Bearer ${KINSTA_API_KEY}" \
+  "$KINSTA_API_URL/sites/$SITE_ID/environments/$ENVIRONMENT_ID/ssh/config")" || true
+
+if [[ "$STATUS_CODE" != "200" ]]; then
+  cat "$CONFIG_FILE" >&2 || true
+  echo "Unable to read SSH details (HTTP $STATUS_CODE)" >&2
+  exit 3
+fi
+
+SSH_USER="$(jq -r '.user // empty' "$CONFIG_FILE")"
+SSH_HOST="$(jq -r '.host // empty' "$CONFIG_FILE")"
+SSH_PORT="$(jq -r '.port // empty' "$CONFIG_FILE")"
+
+if [[ -z "$SSH_USER" || -z "$SSH_HOST" || -z "$SSH_PORT" ]]; then
+  jq -c '.' "$CONFIG_FILE" >&2 || true
+  echo "SSH details incomplete" >&2
+  exit 4
+fi
+
+{
+  echo "SSH_USER=$SSH_USER"
+  echo "SSH_HOST=$SSH_HOST"
+  echo "SSH_PORT=$SSH_PORT"
+} >> "$GITHUB_OUTPUT"
+
+{
+  echo "## Kinsta SSH details for \`$ENVIRONMENT\`"
+  echo
+  echo "Trellis needs these before it can deploy to this environment."
+  echo
+  echo '```'
+  echo "trellis/hosts/$ENVIRONMENT"
+  echo "  kinsta_$ENVIRONMENT ansible_host=$SSH_HOST ansible_port=$SSH_PORT ansible_python_interpreter=/usr/bin/python3"
+  echo
+  echo "bedrock/wp-cli.trellis-alias.yml"
+  echo "  @$ENVIRONMENT:"
+  echo "    ssh: \"$SSH_USER@$SSH_HOST:$SSH_PORT\""
+  echo '```'
+} >> "$GITHUB_STEP_SUMMARY"
+
+echo "SSH: $SSH_USER@$SSH_HOST:$SSH_PORT"

--- a/.github/actions/verify-hostname-routing/action.yml
+++ b/.github/actions/verify-hostname-routing/action.yml
@@ -1,0 +1,26 @@
+---
+name: verify-hostname-routing
+description: Confirm the hostname resolves and is served by Kinsta
+inputs:
+  PRIMARY_DOMAIN:
+    required: true
+  USER_AGENT:
+    description: User agent to send with the request
+    required: false
+    default: ''
+  MAX_ATTEMPTS:
+    required: false
+    default: '20'
+  SLEEP_SECONDS:
+    required: false
+    default: '15'
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: bash "${{ github.action_path }}/run.sh"
+      env:
+        INPUT_PRIMARY_DOMAIN: ${{ inputs.PRIMARY_DOMAIN }}
+        INPUT_USER_AGENT: ${{ inputs.USER_AGENT }}
+        INPUT_MAX_ATTEMPTS: ${{ inputs.MAX_ATTEMPTS }}
+        INPUT_SLEEP_SECONDS: ${{ inputs.SLEEP_SECONDS }}

--- a/.github/actions/verify-hostname-routing/run.sh
+++ b/.github/actions/verify-hostname-routing/run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRIMARY_DOMAIN="${INPUT_PRIMARY_DOMAIN:-}"
+USER_AGENT="${INPUT_USER_AGENT:-}"
+MAX_ATTEMPTS="${INPUT_MAX_ATTEMPTS:-20}"
+SLEEP_SECONDS="${INPUT_SLEEP_SECONDS:-15}"
+
+if [[ -z "$PRIMARY_DOMAIN" ]]; then
+  echo "Missing INPUT_PRIMARY_DOMAIN" >&2
+  exit 2
+fi
+
+if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || ! [[ "$SLEEP_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "MAX_ATTEMPTS and SLEEP_SECONDS must be integers" >&2
+  exit 2
+fi
+
+HEADERS_FILE="${RUNNER_TEMP:?RUNNER_TEMP is not set}/hostname-headers.txt"
+
+for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT++)); do
+  if ! getent hosts "$PRIMARY_DOMAIN" >/dev/null 2>&1; then
+    echo "$PRIMARY_DOMAIN does not resolve yet (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+    sleep "$SLEEP_SECONDS"
+    continue
+  fi
+
+  CURL_ARGS=(--silent --show-error --dump-header "$HEADERS_FILE" --output /dev/null --max-time 20)
+
+  if [[ -n "$USER_AGENT" ]]; then
+    CURL_ARGS+=(--user-agent "$USER_AGENT")
+  fi
+
+  if curl "${CURL_ARGS[@]}" "https://$PRIMARY_DOMAIN/" 2>/dev/null; then
+    if grep -qiE '^ki-' "$HEADERS_FILE"; then
+      echo "$PRIMARY_DOMAIN resolves and is served by Kinsta (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+      grep -iE '^(HTTP/|location:|ki-edge:|ki-origin:)' "$HEADERS_FILE" || true
+      exit 0
+    fi
+
+    STATUS_LINE="$(grep -m1 -i '^HTTP/' "$HEADERS_FILE" | tr -d '\r')"
+    SERVED_BY_CLOUDFLARE=false
+
+    if grep -qiE '^server:[[:space:]]*cloudflare' "$HEADERS_FILE"; then
+      SERVED_BY_CLOUDFLARE=true
+    fi
+
+    # A 403 from Cloudflare is treated as success on purpose, so it is worth
+    # being explicit about why a rejection counts as verification.
+    #
+    # The record's job is to put the hostname in the Cloudflare zone, proxied.
+    # For Cloudflare to answer at all, DNS must have resolved to it, which is
+    # exactly the state being checked; a missing or misdirected record cannot
+    # produce this response. Cloudflare then rejects the request because a CI
+    # runner is not a visitor it trusts, and that rejection is unrelated to
+    # whether the record is correct.
+    #
+    # This confirms less than a ki-* response does, so the pass says which of
+    # the two it was rather than reporting both the same way.
+    if [[ "$SERVED_BY_CLOUDFLARE" == "true" && "$STATUS_LINE" == *" 403"* ]]; then
+      echo "$PRIMARY_DOMAIN is proxied through Cloudflare, which answered with 403 (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+      echo "The record resolves and is proxied. Cloudflare blocked this request, so the origin behind it is unconfirmed."
+      exit 0
+    fi
+
+    echo "::warning::$PRIMARY_DOMAIN responded, but not identifiably from Kinsta or Cloudflare."
+    grep -iE '^(HTTP/|server:|cf-ray:|cf-mitigated:)' "$HEADERS_FILE" || true
+    exit 0
+  else
+    echo "$PRIMARY_DOMAIN did not respond (attempt $ATTEMPT/$MAX_ATTEMPTS)."
+  fi
+
+  sleep "$SLEEP_SECONDS"
+done
+
+echo "$PRIMARY_DOMAIN did not respond after $MAX_ATTEMPTS attempts." >&2
+echo "The DNS record is missing, still propagating, or points nowhere." >&2
+exit 3

--- a/.github/workflows/kinsta-create-env.properties.json
+++ b/.github/workflows/kinsta-create-env.properties.json
@@ -1,0 +1,12 @@
+{
+  "name": "Kinsta create environment",
+  "description": "Create or reuse Kinsta environment and configure domain/DNS",
+  "categories": [
+    "php",
+    "infrastructure"
+  ],
+  "filePatterns": [
+    "composer.json$",
+    "package.json$"
+  ]
+}

--- a/.github/workflows/kinsta-create-env.yml
+++ b/.github/workflows/kinsta-create-env.yml
@@ -1,0 +1,191 @@
+# yamllint disable-line rule:document-start
+name: kinsta-create-env
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      KINSTA_SITE_ID:
+        description: Kinsta site id owning the target environment
+        type: string
+        required: true
+      ENVIRONMENT:
+        description: Name of the environment to create or reuse
+        type: string
+        required: true
+      SOURCE_ENVIRONMENT:
+        description: Environment to clone when the target is missing
+        type: string
+        required: false
+        default: live
+      RUN_SEARCH_AND_REPLACE:
+        description: Rewrite cloned database URLs when setting primary domain
+        type: boolean
+        required: false
+        default: true
+      SHARED_ACTIONS_REF:
+        description: Ref of ItinerisLtd/.github holding the composite actions
+        type: string
+        required: false
+        default: main
+    secrets:
+      KINSTA_API_KEY:
+        required: true
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      CLOUDFLARE_ZONE_ID_DEV:
+        required: true
+      USER_AGENT:
+        required: false
+    outputs:
+      CREATED:
+        description: Whether the target environment was newly created
+        value: ${{ jobs.provision.outputs.CREATED }}
+      ENVIRONMENT_ID:
+        description: Target Kinsta environment id
+        value: ${{ jobs.provision.outputs.ENVIRONMENT_ID }}
+      PRIMARY_DOMAIN:
+        description: Primary domain configured on the environment
+        value: ${{ jobs.provision.outputs.PRIMARY_DOMAIN }}
+      DOMAIN_ID:
+        description: Kinsta domain id for primary domain
+        value: ${{ jobs.provision.outputs.DOMAIN_ID }}
+      DNS_RECORDS_APPLIED:
+        description: Number of Cloudflare DNS records written
+        value: ${{ jobs.provision.outputs.DNS_RECORDS_APPLIED }}
+      SSH_USER:
+        description: SSH user for the environment
+        value: ${{ jobs.provision.outputs.SSH_USER }}
+      SSH_HOST:
+        description: SSH host for the environment
+        value: ${{ jobs.provision.outputs.SSH_HOST }}
+      SSH_PORT:
+        description: SSH port for the environment
+        value: ${{ jobs.provision.outputs.SSH_PORT }}
+
+permissions:
+  contents: read
+
+env:
+  KINSTA_API_URL: https://api.kinsta.com/v2
+  BASE_DOMAIN: itineris.dev
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: >-
+        kinsta-create-${{ inputs.KINSTA_SITE_ID }}-${{ inputs.ENVIRONMENT }}
+      cancel-in-progress: false
+    outputs:
+      CREATED: ${{ steps.summary.outputs.CREATED }}
+      ENVIRONMENT_ID: ${{ steps.summary.outputs.ENVIRONMENT_ID }}
+      PRIMARY_DOMAIN: ${{ steps.summary.outputs.PRIMARY_DOMAIN }}
+      DOMAIN_ID: ${{ steps.summary.outputs.DOMAIN_ID }}
+      DNS_RECORDS_APPLIED: ${{ steps.summary.outputs.DNS_RECORDS_APPLIED }}
+      SSH_USER: ${{ steps.summary.outputs.SSH_USER }}
+      SSH_HOST: ${{ steps.summary.outputs.SSH_HOST }}
+      SSH_PORT: ${{ steps.summary.outputs.SSH_PORT }}
+    steps:
+      - name: Checkout shared actions
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: ItinerisLtd/.github
+          ref: ${{ inputs.SHARED_ACTIONS_REF }}
+          path: .itineris-actions
+          persist-credentials: false
+
+      - name: Find or create environment
+        id: environment
+        uses: ./.itineris-actions/.github/actions/kinsta-find-or-create-env
+        with:
+          SITE_ID: ${{ inputs.KINSTA_SITE_ID }}
+          TARGET_ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
+          SOURCE_ENVIRONMENT: ${{ inputs.SOURCE_ENVIRONMENT }}
+          KINSTA_API_URL: ${{ env.KINSTA_API_URL }}
+          KINSTA_API_KEY: ${{ secrets.KINSTA_API_KEY }}
+
+      - name: Attach domain and build pointing record
+        id: domain
+        uses: ./.itineris-actions/.github/actions/kinsta-attach-domain
+        with:
+          SITE_ID: ${{ inputs.KINSTA_SITE_ID }}
+          ENVIRONMENT_ID: ${{ steps.environment.outputs.ENVIRONMENT_ID }}
+          REPOSITORY: ${{ github.repository }}
+          BASE_DOMAIN: ${{ env.BASE_DOMAIN }}
+          KINSTA_API_URL: ${{ env.KINSTA_API_URL }}
+          KINSTA_API_KEY: ${{ secrets.KINSTA_API_KEY }}
+
+      - name: Collect DNS records from Kinsta
+        id: records
+        if: ${{ steps.domain.outputs.DOMAIN_ID != '' }}
+        uses: ./.itineris-actions/.github/actions/kinsta-collect-dns-records
+        with:
+          DOMAIN_ID: ${{ steps.domain.outputs.DOMAIN_ID }}
+          PRIMARY_DOMAIN: ${{ steps.domain.outputs.PRIMARY_DOMAIN }}
+          KINSTA_API_URL: ${{ env.KINSTA_API_URL }}
+          KINSTA_API_KEY: ${{ secrets.KINSTA_API_KEY }}
+
+      - name: Add DNS records to Cloudflare
+        id: dns
+        if: >-
+          ${{ steps.domain.outputs.RECORDS_JSON != ''
+          && steps.records.outputs.DNS_READY != 'true' }}
+        uses: ./.itineris-actions/.github/actions/cloudflare-add-records
+        with:
+          ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID_DEV }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          RECORDS_JSON: ${{ steps.domain.outputs.RECORDS_JSON }}
+          ADDITIONAL_RECORDS_JSON: ${{ steps.records.outputs.RECORDS_JSON }}
+
+      - name: Set primary domain and search-replace URLs
+        if: ${{ steps.domain.outputs.DOMAIN_ID != '' }}
+        uses: ./.itineris-actions/.github/actions/kinsta-set-primary-domain
+        with:
+          SITE_ID: ${{ inputs.KINSTA_SITE_ID }}
+          ENVIRONMENT_ID: ${{ steps.environment.outputs.ENVIRONMENT_ID }}
+          DOMAIN_ID: ${{ steps.domain.outputs.DOMAIN_ID }}
+          RUN_SEARCH_AND_REPLACE: ${{ inputs.RUN_SEARCH_AND_REPLACE }}
+          KINSTA_API_URL: ${{ env.KINSTA_API_URL }}
+          KINSTA_API_KEY: ${{ secrets.KINSTA_API_KEY }}
+
+      - name: Verify hostname reaches Kinsta
+        if: ${{ steps.domain.outputs.PRIMARY_DOMAIN != '' }}
+        uses: ./.itineris-actions/.github/actions/verify-hostname-routing
+        with:
+          PRIMARY_DOMAIN: ${{ steps.domain.outputs.PRIMARY_DOMAIN }}
+          USER_AGENT: ${{ secrets.USER_AGENT }}
+
+      - name: Read SSH details
+        id: ssh
+        uses: ./.itineris-actions/.github/actions/kinsta-ssh-details
+        with:
+          SITE_ID: ${{ inputs.KINSTA_SITE_ID }}
+          ENVIRONMENT_ID: ${{ steps.environment.outputs.ENVIRONMENT_ID }}
+          ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
+          KINSTA_API_URL: ${{ env.KINSTA_API_URL }}
+          KINSTA_API_KEY: ${{ secrets.KINSTA_API_KEY }}
+
+      - name: Build summary outputs
+        id: summary
+        env:
+          CREATED: ${{ steps.environment.outputs.CREATED }}
+          ENVIRONMENT_ID: ${{ steps.environment.outputs.ENVIRONMENT_ID }}
+          PRIMARY_DOMAIN: ${{ steps.domain.outputs.PRIMARY_DOMAIN }}
+          DOMAIN_ID: ${{ steps.domain.outputs.DOMAIN_ID }}
+          DNS_RECORDS_APPLIED: ${{ steps.dns.outputs.RECORDS_APPLIED }}
+          SSH_USER: ${{ steps.ssh.outputs.SSH_USER }}
+          SSH_HOST: ${{ steps.ssh.outputs.SSH_HOST }}
+          SSH_PORT: ${{ steps.ssh.outputs.SSH_PORT }}
+        run: |
+          set -euo pipefail
+          {
+            printf 'CREATED=%s\n' "$CREATED"
+            printf 'ENVIRONMENT_ID=%s\n' "$ENVIRONMENT_ID"
+            printf 'PRIMARY_DOMAIN=%s\n' "$PRIMARY_DOMAIN"
+            printf 'DOMAIN_ID=%s\n' "$DOMAIN_ID"
+            printf 'DNS_RECORDS_APPLIED=%s\n' "${DNS_RECORDS_APPLIED:-0}"
+            printf 'SSH_USER=%s\n' "$SSH_USER"
+            printf 'SSH_HOST=%s\n' "$SSH_HOST"
+            printf 'SSH_PORT=%s\n' "$SSH_PORT"
+          } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Adds `kinsta-create-env.yml`, a `workflow_call` workflow that idempotently creates a Kinsta environment and wires up its domain and DNS.

Where the target environment is missing it clones the source environment (default `live`), attaches the project hostname, adds any DNS records Cloudflare is missing, promotes the hostname to primary with a database search-replace, and confirms the hostname is served by Kinsta. Where it already exists, each step reconciles instead of duplicating.

API behaviour lives in six composite actions, each with an explicit input/output contract:

| Action | Responsibility |
|---|---|
| `kinsta-find-or-create-env` | Find the environment or clone it, poll the operation, wait for the lock |
| `kinsta-attach-domain` | Derive the project hostname, attach it, emit its pointing record |
| `kinsta-collect-dns-records` | Collect the records Kinsta wants, decide whether any need adding |
| `cloudflare-add-records` | Add those records to one Cloudflare zone |
| `kinsta-set-primary-domain` | Promote the hostname and rewrite the cloned database URLs |
| `verify-hostname-routing` | Confirm the hostname resolves and Kinsta answers it |
| `kinsta-ssh-details` | Read the environment's SSH user, host and port |

## Contract

**Inputs:** `KINSTA_SITE_ID` (required), `ENVIRONMENT` (required), `SOURCE_ENVIRONMENT` (default `live`), `RUN_SEARCH_AND_REPLACE` (default `true`), `SHARED_ACTIONS_REF` (default `main`).

**Secrets:** `KINSTA_API_KEY`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID_DEV`, and optionally `USER_AGENT`.

**Outputs:** `CREATED`, `ENVIRONMENT_ID`, `PRIMARY_DOMAIN`, `DOMAIN_ID`, `DNS_RECORDS_APPLIED`, `SSH_USER`, `SSH_HOST`, `SSH_PORT`.

## What the Kinsta API cannot do

These are the parts of environment setup this workflow deliberately leaves alone, because the API offers no way to perform them. Checked against the full OpenAPI specification (v1.106.0, all 84 paths).

| Wanted | Status |
|---|---|
| Password protection / basic auth | **No endpoint.** Nothing matches `htpasswd`, basic auth, password protection, site lock or maintenance. The only password endpoints cover SFTP/SSH. Remains a MyKinsta panel step. |
| Enable server-side caching | **No toggle.** The cache endpoints are `clear-cache`, `edge-caching/clear`, `edge-caching/status` and `cdn/clear-cache`. Only edge caching can be enabled or disabled; server-side caching can be cleared but not switched. |
| Remove the default `.kinsta.cloud` domain | **Forbidden.** `DELETE /sites/environments/{env_id}/domains` accepts the request and returns 202, then fails the operation with "This action cannot delete temporary domains". MyKinsta offers no way either, so an environment keeps its temporary hostname and wildcard permanently. |
| Know whether a domain is verified | **Not exposed.** A site domain carries only `id`, `name`, `type`, `site_id` and `uses_cloudflare_dns`; there is no verified, pointed or certificate state, and `force-https-status` is environment-wide. MyKinsta's checkmark comes from outside the public API. The workflow checks the hostname directly instead. |
| Fetch one environment by id | **Not available.** Only `GET /sites/{site_id}/environments`, which returns all of them. Caching an environment id therefore saves no API call, which is why no such cache exists here. |

Two further behaviours are worked around rather than avoided:

- **An operation is not queryable straight after its 202.** Polled immediately, `GET /operations/{id}` answers 404 "does not exist or failed on initialization", or a 200 success before any work has started. Polling waits one interval before its first request, and reads the numeric `status` in the body rather than the HTTP code, which can disagree.
- **A completed operation does not mean the work is done.** `change-primary-domain` reported "successfully finished" 63 seconds before Kinsta released the environment, with the search-replace still running. `is_blocked` on the environments list is the only signal spanning both, so mutating steps wait for it to clear.

## Things worth knowing

**The workflow checks itself out.** A reusable workflow resolves `uses: ./...` against the *caller's* workspace, so the composite actions are unreachable without an explicit checkout. The workflow checks this repository out into `.itineris-actions/` at the `SHARED_ACTIONS_REF` input, which defaults to `main`; a caller pinned to a tag should pass the same tag, or the workflow and its actions can drift apart. No context exposes a reusable workflow's own commit SHA (`github.workflow_sha` is the caller's, and `job_workflow_sha` is an OIDC claim rather than a context), so this cannot be automatic.

**Deploying to a new environment is a manual follow-up, and worth automating later.** A cloned environment gets a new SSH port, so Trellis cannot reach it until two files are updated by hand:

```
trellis/hosts/<env>            ansible_host, ansible_port
bedrock/wp-cli.trellis-alias.yml   ssh: "<user>@<host>:<port>" under @<env>
```

The workflow now removes the tedious half of that: it reads the SSH user, host and port from `GET /sites/{site_id}/environments/{env_id}/ssh/config`, exposes them as outputs, and prints both file snippets in the run summary ready to paste.

Automating the rest is a follow-up, and the two project types need different treatment:

| Project type | Where the details live | What automating it takes |
|---|---|---|
| Bedrock + Trellis | `trellis/hosts/<env>` and `wp-cli.trellis-alias.yml` | A PR to each repository, with the Trellis one **merged first** — merging the Bedrock one triggers a deploy that reads the Trellis host file. Enforcing that ordering means either gating the second PR on the Trellis file's content and running twice, or a dispatch from the Trellis repository on merge |
| Newer projects | GitHub variables: `SSH_USER` and `SSH_HOST` at repository level, `SSH_PORT` scoped to the environment | One API call per value, plus creating the GitHub Environment if absent. `deploy-wp.yml` sets `environment:` on its job and reads `vars.SSH_PORT` there, while the caller passes `SSH_USER` and `SSH_HOST` from repository variables. The split works because only the port differs between Kinsta environments |

The second is much the simpler of the two and worth doing first. It needs a PAT, because `GITHUB_TOKEN` cannot be granted access to the Actions variables API — the `permissions:` block has no `variables` scope.

Note the endpoint returns a flat `{user, host, port}` object, not the nested `activeContainer` shape the OpenAPI specification documents.

**A created environment does not serve correctly until it is deployed.** The search-replace rewrites URLs in the database, but Bedrock reads `WP_HOME` and `WP_SITEURL` from `.env`, so a clone keeps the source environment's configuration and redirects to it until a deploy lands. "create-env succeeded" and "the environment serves correctly" are separate milestones.

## Domain convention

The hostname is derived from the calling repository rather than configured per project:

| Repository | Project name |
|---|---|
| `www.example.org-bedrock` | `example` |
| `www.example.org.uk-bedrock` | `example` |
| `www.example-site.co.uk-trellis` | `example-site` |
| `www.example.ac.uk` | `example` |
| `example-project` | `example-project` |

A trailing `-bedrock`, `-trellis` or `-radicle` is stripped if present, then a leading `www.`, then everything from the first remaining dot onwards. Newer projects on neither stack carry no suffix, so the strip is simply a no-op for them; a repository with no dots at all is used as-is. The project name is joined to the workflow's `BASE_DOMAIN`, and the pointing record is a proxied CNAME to `<project>.hosting.kinsta.cloud`.

## Limitations of this workflow

- **One created environment per project.** The hostname carries no environment name, so a second environment on the same site would contend for the same hostname.
- **An existing DNS record is trusted, not checked.** The Cloudflare step is skipped when the hostname already resolves, and a resolver cannot see proxy state or the target behind a proxied record.
- **The actions checkout assumes this repository stays public.** If it is made private, the checkout needs a token with access to it.

## Outstanding

Tracked here so nothing is assumed done. None of these block what the workflow currently claims to do.

**Before merge**

- [ ] Remove the temporary `push` trigger from the calling repository's `create-env.yml`, added so the workflow could be exercised without merging first
- [ ] Tag this repository after merge, then move both the caller's `uses:` ref and its `SHARED_ACTIONS_REF` off the branch and onto that tag

**Untested against the live APIs**

- [ ] **Writing a DNS record to Cloudflare.** Every run so far had the record already in place, so the step was skipped each time. Needs `CLOUDFLARE_API_TOKEN`, which does not yet exist as a secret, and a hostname that has never been pointed. Until then, record creation, the CNAME-beats-A precedence and the proxied flag are unproven in practice
- [ ] **Verification records from the `avoid_downtime` setup flow.** Domains are attached with `setup_type: quick`, so Kinsta has only ever returned pointing records. The branch that marks `kinsta-verification` TXT and `_acme-challenge` CNAME records as DNS-only has never run
- [ ] **A repository whose hostname resolves but points somewhere wrong.** The Cloudflare step is skipped on resolution alone, so a stale or misdirected record would not be corrected

**Not built**

- [ ] **Writing the SSH details where each project expects them.** The values are surfaced in the run summary but applied by hand: two files via PRs for Bedrock and Trellis, or repository and environment variables for newer projects. See the table above
- [ ] **Creating a whole new Kinsta site.** This workflow only clones an environment on a site that already exists. New projects need `POST /sites` or `POST /sites/clone`, which is a separate flow with its own inputs (company, region, admin credentials) and deserves its own workflow reusing these actions
- [ ] **Password protection, server-side caching, removing the default domain.** Not possible through the API; see the table above. They stay manual MyKinsta steps

**Known behaviour, not a defect**

- A created environment redirects to the live domain until something deploys to it, because Bedrock reads `WP_HOME` from `.env` rather than the database

## Testing

`actionlint`, `yamllint` and `shellcheck` are clean across the workflow and all seven actions.

Exercised against a live Kinsta site over two dozen runs, including several from a freshly deleted environment. A clean run completes in about six minutes, of which the clone is three and a half.

| Step | Verified live |
|---|---|
| Checkout shared actions | yes |
| Find or create environment | yes, both the clone path and reuse |
| Attach domain and build pointing record | yes, both a fresh add and reuse |
| Collect DNS records from Kinsta | yes, both a returned pointing record and the empty "already pointed" case |
| Add DNS records to Cloudflare | **no** — every run had the record already in place, so the step was skipped. Needs a hostname that has never been pointed, plus `CLOUDFLARE_API_TOKEN` |
| Set primary domain + search-replace | yes, including the no-op when already primary |
| Verify hostname reaches Kinsta | yes, both the `ki-*` and Cloudflare-403 branches |
| Read SSH details | yes |
